### PR TITLE
Add category CRUD API and docs

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -1,0 +1,42 @@
+# Endpoints de l'API
+
+Cette page liste les routes disponibles de l'API Express.
+
+## Catégories
+
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| GET | /categories | Liste des catégories |
+| GET | /categories/:id | Détail d'une catégorie |
+| POST | /categories | Créer une catégorie |
+| PUT | /categories/:id | Modifier une catégorie |
+| DELETE | /categories/:id | Supprimer une catégorie |
+
+## Produits
+
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| GET | /items | Liste des produits |
+| GET | /items/:id | Détail d'un produit |
+| POST | /items | Créer un produit |
+| PUT | /items/:id | Modifier un produit |
+| DELETE | /items/:id | Supprimer un produit |
+
+## Commandes
+
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| GET | /orders | Liste des commandes |
+| GET | /orders/user/:userId | Commandes d'un utilisateur |
+| GET | /orders/:id | Détail d'une commande |
+| POST | /orders | Créer une commande |
+| PUT | /orders/:id/status | Modifier le statut d'une commande |
+| DELETE | /orders/:id | Supprimer une commande |
+
+## Utilisateurs
+
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| POST | /users/register | Inscription |
+| POST | /users/login | Connexion |
+| GET | /users/:id | Profil utilisateur |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ E-Commerce showcase site. Suitable for making reservations. Administration panel
 ## Sommaire : 
 - [Liste des pages de l'application](./Docs/Pages.md)
 - [La base de donnée](./Docs/BDD.md)
+- [Endpoints de l'API](./Docs/API.md)
 
 ## Arborescence du projet
 

--- a/Server/controllers/categoryController.js
+++ b/Server/controllers/categoryController.js
@@ -8,3 +8,44 @@ exports.getAllCategories = async (req, res) => {
     res.status(500).json({ error: 'Erreur serveur' });
   }
 };
+
+exports.getCategoryById = async (req, res) => {
+  try {
+    const { rows } = await db.query('SELECT * FROM category WHERE id = $1', [req.params.id]);
+    if (rows.length === 0) return res.status(404).json({ error: 'Catégorie introuvable' });
+    res.json(rows[0]);
+  } catch (err) {
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+exports.createCategory = async (req, res) => {
+  const { name } = req.body;
+  try {
+    const { rows } = await db.query('INSERT INTO category (name) VALUES ($1) RETURNING *', [name]);
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+exports.updateCategory = async (req, res) => {
+  const { name } = req.body;
+  try {
+    const { rows } = await db.query('UPDATE category SET name=$1 WHERE id=$2 RETURNING *', [name, req.params.id]);
+    if (rows.length === 0) return res.status(404).json({ error: 'Catégorie introuvable' });
+    res.json(rows[0]);
+  } catch (err) {
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+exports.deleteCategory = async (req, res) => {
+  try {
+    const result = await db.query('DELETE FROM category WHERE id=$1', [req.params.id]);
+    if (result.rowCount === 0) return res.status(404).json({ error: 'Catégorie introuvable' });
+    res.json({ message: 'Catégorie supprimée' });
+  } catch (err) {
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};

--- a/Server/routes/categories.js
+++ b/Server/routes/categories.js
@@ -1,7 +1,17 @@
 const express = require('express');
 const router = express.Router();
-const { getAllCategories } = require('../controllers/categoryController');
+const {
+  getAllCategories,
+  getCategoryById,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} = require('../controllers/categoryController');
 
 router.get('/', getAllCategories);
+router.get('/:id', getCategoryById);
+router.post('/', createCategory);
+router.put('/:id', updateCategory);
+router.delete('/:id', deleteCategory);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- implement create/update/delete category endpoints
- list all API endpoints in new documentation
- link to API docs in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in Client *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ab3273104832f91543720eb45a3f1