### PR TITLE
Link front to API

### DIFF
--- a/Client/public/index.html
+++ b/Client/public/index.html
@@ -31,38 +31,7 @@
 </header>
 
 <div class="container my-5">
-  <div class="row g-4">
-    <div class="col-md-4">
-      <div class="card h-100">
-        <img src="https://via.placeholder.com/350x200" class="card-img-top" alt="Produit 1">
-        <div class="card-body d-flex flex-column">
-          <h5 class="card-title">Produit 1</h5>
-          <p class="card-text">Un super produit pour démarrer votre shopping.</p>
-          <button class="btn btn-primary mt-auto add-to-cart">Ajouter au panier</button>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="card h-100">
-        <img src="https://via.placeholder.com/350x200" class="card-img-top" alt="Produit 2">
-        <div class="card-body d-flex flex-column">
-          <h5 class="card-title">Produit 2</h5>
-          <p class="card-text">Encore un article incontournable de la boutique.</p>
-          <button class="btn btn-primary mt-auto add-to-cart">Ajouter au panier</button>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="card h-100">
-        <img src="https://via.placeholder.com/350x200" class="card-img-top" alt="Produit 3">
-        <div class="card-body d-flex flex-column">
-          <h5 class="card-title">Produit 3</h5>
-          <p class="card-text">Un indispensable pour compléter votre commande.</p>
-          <button class="btn btn-primary mt-auto add-to-cart">Ajouter au panier</button>
-        </div>
-      </div>
-    </div>
-  </div>
+  <div class="row g-4" id="items-container"></div>
 </div>
 
 <footer class="bg-dark text-white text-center py-3">
@@ -70,6 +39,6 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script src="../src/client.js"></script>
+<script src="../src/client.js" type="module"></script>
 </body>
 </html>

--- a/Client/public/product.html
+++ b/Client/public/product.html
@@ -24,14 +24,14 @@
 </nav>
 
 <div class="container my-5">
-  <div class="row">
+  <div class="row" id="product-detail">
     <div class="col-md-6">
-      <img class="img-fluid" src="https://via.placeholder.com/600x400" alt="Produit détaillé">
+      <img class="img-fluid" src="" alt="Produit">
     </div>
     <div class="col-md-6">
-      <h1>Nom du produit</h1>
-      <p class="lead">Ici se trouve une description détaillée du produit. Elle présente ses caractéristiques principales, ses avantages et toutes les informations utiles pour le client.</p>
-      <p class="h4">49,99 €</p>
+      <h1></h1>
+      <p class="lead"></p>
+      <p class="h4"></p>
       <button class="btn btn-primary add-to-cart">Ajouter au panier</button>
     </div>
   </div>
@@ -42,6 +42,6 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script src="../src/client.js"></script>
+<script src="../src/client.js" type="module"></script>
 </body>
 </html>

--- a/Client/public/shop.html
+++ b/Client/public/shop.html
@@ -25,53 +25,13 @@
 
 <div class="container my-5">
   <h1 class="mb-4">Nos produits</h1>
-  <div class="row g-4">
-    <div class="col-md-3" >
-      <div class="card h-100">
-        <img src="https://via.placeholder.com/300x180" class="card-img-top" alt="Produit A">
-        <div class="card-body d-flex flex-column">
-          <h5 class="card-title">Produit A</h5>
-          <p class="card-text">Petit descriptif du produit A.</p>
-          <a href="product.html" class="btn btn-outline-primary mt-auto">Voir</a>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <div class="card h-100">
-        <img src="https://via.placeholder.com/300x180" class="card-img-top" alt="Produit B">
-        <div class="card-body d-flex flex-column">
-          <h5 class="card-title">Produit B</h5>
-          <p class="card-text">Petit descriptif du produit B.</p>
-          <a href="product.html" class="btn btn-outline-primary mt-auto">Voir</a>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <div class="card h-100">
-        <img src="https://via.placeholder.com/300x180" class="card-img-top" alt="Produit C">
-        <div class="card-body d-flex flex-column">
-          <h5 class="card-title">Produit C</h5>
-          <p class="card-text">Petit descriptif du produit C.</p>
-          <a href="product.html" class="btn btn-outline-primary mt-auto">Voir</a>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <div class="card h-100">
-        <img src="https://via.placeholder.com/300x180" class="card-img-top" alt="Produit D">
-        <div class="card-body d-flex flex-column">
-          <h5 class="card-title">Produit D</h5>
-          <p class="card-text">Petit descriptif du produit D.</p>
-          <a href="product.html" class="btn btn-outline-primary mt-auto">Voir</a>
-        </div>
-      </div>
-    </div>
-  </div>
+  <div class="row g-4" id="items-container"></div>
 </div>
 
 <footer class="bg-dark text-white text-center py-3 mt-auto">
   <p class="mb-0">&copy; 2024 E-Shop - Interface de démonstration</p>
 </footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="../src/client.js" type="module"></script>
 </body>
 </html>

--- a/Client/src/api.js
+++ b/Client/src/api.js
@@ -1,0 +1,13 @@
+const API_URL = 'http://localhost:3001';
+
+export async function getItems() {
+  const res = await fetch(`${API_URL}/items`);
+  if (!res.ok) throw new Error('Erreur lors du chargement des produits');
+  return res.json();
+}
+
+export async function getItem(id) {
+  const res = await fetch(`${API_URL}/items/${id}`);
+  if (!res.ok) throw new Error('Erreur lors du chargement du produit');
+  return res.json();
+}

--- a/Client/src/client.js
+++ b/Client/src/client.js
@@ -1,6 +1,48 @@
-// Script front simple pour la démo
+import { getItems, getItem } from './api.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+// Gestion des différentes pages
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const listContainer = document.querySelector('#items-container');
+  if (listContainer) {
+    try {
+      const items = await getItems();
+      items.forEach(item => {
+        const col = document.createElement('div');
+        col.className = 'col-md-3';
+        col.innerHTML = `
+          <div class="card h-100">
+            <img src="${item.picture}" class="card-img-top" alt="${item.name}">
+            <div class="card-body d-flex flex-column">
+              <h5 class="card-title">${item.name}</h5>
+              <p class="card-text">${item.description}</p>
+              <a href="product.html?id=${item.id}" class="btn btn-outline-primary mt-auto">Voir</a>
+            </div>
+          </div>`;
+        listContainer.appendChild(col);
+      });
+    } catch (e) {
+      listContainer.innerHTML = '<p class="text-danger">Erreur de chargement</p>';
+    }
+  }
+
+  const detailContainer = document.querySelector('#product-detail');
+  if (detailContainer) {
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    if (id) {
+      try {
+        const item = await getItem(id);
+        detailContainer.querySelector('img').src = item.picture;
+        detailContainer.querySelector('h1').textContent = item.name;
+        detailContainer.querySelector('p.lead').textContent = item.description;
+        detailContainer.querySelector('.h4').textContent = (item.price / 100).toFixed(2) + ' €';
+      } catch (e) {
+        detailContainer.innerHTML = '<p class="text-danger">Produit introuvable</p>';
+      }
+    }
+  }
+
   const buttons = document.querySelectorAll('.add-to-cart');
   buttons.forEach(btn => {
     btn.addEventListener('click', (e) => {

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ E-Commerce showcase site. Suitable for making reservations. Administration panel
 │   ├── db.js          # Connexion à PostgreSQL
 │   └── index.js       # Point d'entrée du serveur
 │
-├── 📁 Client/         # (Front‑end à venir)
+├── 📁 Client/         # Pages statiques et scripts du front
 │   └── src/
+│       ├── api.js
 │       └── client.js
 │
 ├── 📁 Database/       # Scripts SQL
@@ -64,3 +65,6 @@ E-Commerce showcase site. Suitable for making reservations. Administration panel
    ```bash
    node index.js
    ```
+
+5. Ouvrir `Client/public/index.html` dans un navigateur. Les pages utilisent l'API
+   (port 3001 par défaut) pour afficher les produits.


### PR DESCRIPTION
## Summary
- connect front pages to backend API
- fetch item list and details via new JS API helper
- update pages to load data dynamically
- document running the updated frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ab466ef98832fa7b998fb3e03689a