### PR TITLE
docs: refresh technical guides

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -1,66 +1,50 @@
 # Endpoints de l'API
 
-Cette page liste les routes disponibles de l'API Express et leur statut d'intégration avec Supabase.
+Petit tour d’horizon des routes REST utilisées par la boutique. Les appels
+s’appuient sur Supabase pour l’authentification et la base de données.
 
 ## Catégories
 
-| Méthode | Route | Description |
-|---------|-------|-------------|
-| GET | /categories | Liste des catégories |
-| GET | /categories/:id | Détail d'une catégorie |
-| POST | /categories | Créer une catégorie |
-| PUT | /categories/:id | Modifier une catégorie |
-| DELETE | /categories/:id | Supprimer une catégorie |
+- `GET /categories` — toutes les catégories
+- `GET /categories/:id` — détail d’une catégorie
+- `POST /categories` — ajouter (admin)
+- `PUT /categories/:id` — modifier (admin)
+- `DELETE /categories/:id` — supprimer (admin)
 
-## Produits (items)
+## Produits
 
-| Méthode | Route | Description |
-|---------|-------|-------------|
-| GET | /items | Liste des produits |
-| GET | /items/:id | Détail d'un produit |
-| POST | /items | Créer un produit (admin seulement) |
-| PUT | /items/:id | Modifier un produit (admin seulement) |
-| DELETE | /items/:id | Supprimer un produit (admin seulement) |
+- `GET /items` — liste des produits
+- `GET /items/:id` — fiche produit
+- `POST /items` — créer (admin)
+- `PUT /items/:id` — mettre à jour (admin)
+- `DELETE /items/:id` — retirer (admin)
 
-**✅ Ajouts récents :**
-- Intégration du stockage d'image via Supabase Storage.
-- Les URLs des images sont stockées dans `image_url`.
-- Prise en charge des variantes via `/items/:id/variants`.
+Les images sont stockées dans Supabase Storage et référencées via `image_url`.
+Une route dédiée gère les variantes : `GET /items/:id/variants`.
 
-## Variantes de produits
+## Variantes
 
-| Méthode | Route | Description |
-|---------|-------|-------------|
-| GET | /items/:id/variants | Liste des variantes d’un produit |
-| POST | /items/:id/variants | Ajouter une variante (admin seulement) |
-| PUT | /variants/:variantId | Modifier une variante |
-| DELETE | /variants/:variantId | Supprimer une variante |
+- `GET /items/:id/variants` — variations d’un produit
+- `POST /items/:id/variants` — ajouter (admin)
+- `PUT /variants/:variantId` — modifier
+- `DELETE /variants/:variantId` — supprimer
 
 ## Commandes
 
-| Méthode | Route | Description |
-|---------|-------|-------------|
-| GET | /orders | Liste des commandes |
-| GET | /orders/user/:userId | Commandes d'un utilisateur |
-| GET | /orders/:id | Détail d'une commande |
-| POST | /orders | Créer une commande |
-| PUT | /orders/:id/status | Modifier le statut d'une commande |
-| DELETE | /orders/:id | Supprimer une commande |
+- `GET /orders` — toutes les commandes (admin)
+- `GET /orders/user/:userId` — historique d’un client
+- `GET /orders/:id` — détail d’une commande
+- `POST /orders` — créer une commande
+- `PUT /orders/:id/status` — changer le statut
+- `DELETE /orders/:id` — annuler (admin)
 
-**✅ Ajout :** Champ `customization` supporté (champ JSON libre).
+Champ libre `customization` accepté pour préciser un message ou une option.
 
 ## Utilisateurs
 
-| Méthode | Route | Description |
-|---------|-------|-------------|
-| POST | /users/register | Inscription via Supabase Auth |
-| POST | /users/login | Connexion via Supabase Auth |
-| GET | /users/:id | Profil utilisateur (requiert token) |
+- `POST /users/register` — inscription via Supabase Auth
+- `POST /users/login` — connexion
+- `GET /users/:id` — profil (token requis)
 
-**✅ Ajout :** Gestion des rôles (`client`, `admin`) intégrée via Supabase RLS.
-
-## Sécurité et Accès
-
-- Ajout d’un système de rôles via Supabase (`auth.users` + table `profiles` ou `users` personnalisée).
-- Middleware `PrivateRoute` sur le front selon rôle.
-- JWT automatiquement généré par Supabase et stocké en local.
+Les rôles `client` et `admin` sont gérés automatiquement par Supabase et
+définissent l’accès aux routes.

--- a/Docs/Architecture.md
+++ b/Docs/Architecture.md
@@ -1,72 +1,45 @@
 # Architecture de l'application
 
-Cette application s'appuie principalement sur **React** pour le front‑end et **Supabase** pour les services back‑end (authentification, base de données PostgreSQL et stockage d'images).
+L’application s’articule autour de **React** pour l’interface et de
+**Supabase** pour la base de données, l’authentification et le stockage
+des images.
 
-## Vue d'ensemble
+## Vue d’ensemble
 
 ![Flux global](./Assets/front_way_to_work.png)
 
-1. L'utilisateur navigue sur l'application React.
-2. Les appels API sont effectués directement vers Supabase via son client JavaScript.
-3. Les images des produits sont hébergées dans Supabase Storage.
-4. Les règles de sécurité (RLS) assurent que seules les requêtes autorisées sont exécutées.
+1. L’utilisateur navigue sur le front React.
+2. Les requêtes partent directement vers Supabase grâce à son client JS.
+3. Les images des produits vivent dans Supabase Storage.
+4. Les règles RLS de Supabase filtrent les accès.
 
 ## Authentification
 
 ![Schéma d'auth](./Assets/diagAuth.png)
 
-- Gestion des comptes via Supabase Auth.
-- Les informations de session (JWT) sont conservées côté client et utilisées pour les requêtes sécurisées.
+- Comptes gérés par Supabase Auth.
+- Le jeton de session (JWT) reste côté navigateur pour les appels sécurisés.
 
-Cette architecture réduit la quantité de code serveur à maintenir et permet un déploiement simple sur des plateformes statiques comme Vercel.
+Ce choix limite la quantité de code serveur et facilite le déploiement sur
+une plateforme statique comme Vercel.
 
-## Arborescence du projet
+## Structure du projet
 
 ```plaintext
 E-Commerce/
-├── client/                          # Frontend (React + Vite + Tailwind)
-│   ├── public/
-│   ├── src/
-│   │   ├── assets/                  # Logos, images, SVGs
-│   │   ├── components/             # Navbar, ProductCard, etc.
-│   │   ├── pages/                  # Home, Shop, Product, Cart, Admin...
-│   │   │   └── Admin/              # Dashboard, ProductForm, VariantForm
-│   │   ├── api/                    # Fonctions API via Supabase
-│   │   ├── auth/                   # AuthContext + hook + role check
-│   │   ├── context/                # CartContext (et autres si besoin)
-│   │   ├── utils/                  # formatPrice, role utils, etc.
-│   │   ├── supabase/               # Supabase client config
-│   │   │   └── client.js
-│   │   ├── App.jsx                 # Routes + Layout
-│   │   ├── index.js                # Entrée React
-│   │   └── styles/                 # main.css ou tailwind.css
-│   │
-│   ├── .env.local                  # SUPABASE_URL / SUPABASE_ANON_KEY
-│   └── vite.config.js
-│
-├── Database/                        # Scripts SQL
-│   ├── bd.sql                       # Création des tables
-│   └── populate.sql                 # Données de test
-│
-├── Docs/                           # Spécifications et maquettes
-│   ├── Assets/                      # Images utilisées dans la doc
-│   ├── API.md
-│   ├── BDD.md
-│   ├── Pages.md
-│   └── Architecture.md
-│
-└── README.md
-
+├── client/           # Frontend React
+│   └── src/          # composants, pages et hooks
+├── Database/         # scripts SQL
+└── Docs/             # documentation
 ```
 
-### Stack technique du projet
+### Stack technique
 
-| Couche          | Choix recommandé                                     |
-| --------------- | ---------------------------------------------------- |
-| Frontend        | React + Vite + Tailwind                              |
-| Backend         | Supabase (API + Auth)                                |
-| BDD             | Supabase PostgreSQL                                  |
-| Stockage images | Supabase Storage                                     |
-| Paiement        | Stripe                                               |
-| Déploiement     | Vercel (front)                                       |
-| Monitoring      | Sentry                                               |
+| Couche      | Outil                        |
+|-------------|------------------------------|
+| Frontend    | React, Vite, Tailwind        |
+| Backend     | Supabase (API + Auth)        |
+| Base de données | Supabase PostgreSQL     |
+| Stockage    | Supabase Storage             |
+| Paiement    | Stripe                       |
+| Déploiement | Vercel                       |

--- a/Docs/BDD.md
+++ b/Docs/BDD.md
@@ -1,78 +1,51 @@
 
-# 📦 Base de Données E-commerce - Supabase
+# 📦 Base de données
 
-## 📚 Tables principales
+Aperçu des tables principales utilisées par la boutique Supabase.
 
-### `items`
-| Champ       | Type         | Description                          |
-|-------------|--------------|--------------------------------------|
-| id          | integer      | Identifiant unique                   |
-| name        | text         | Nom                                  |
-| description | text         | Description complète                 |
-| base_price  | integer      | Prix de base (en centimes)           |
-| image_url   | text         | URL vers l'image stockée             |
-| created_at  | timestamp    | Date d'ajout                         |
+## `items`
 
-✅ Images stockées dans Supabase Storage via bucket `product-images`.
+- `id` — identifiant
+- `name`, `description` — infos produit
+- `base_price` — prix de base en centimes
+- `image_url` — URL d’illustration (Supabase Storage)
+- `created_at` — date d’ajout
 
----
+## `item_variants`
 
-### `item_variants`
-| Champ       | Type         | Description                          |
-|-------------|--------------|--------------------------------------|
-| id          | integer      | Identifiant                          |
-| item_id     | integer      | Référence vers `items.id`            |
-| color       | text         | Couleur                              |
-| format      | text         | Format / taille                      |
-| stock       | integer      | Stock disponible                     |
-| extra_price | integer      | Surcoût optionnel (centimes)        |
+- `id`, `item_id`
+- `color`, `format`
+- `stock` — quantité disponible
+- `extra_price` — surcoût éventuel
 
-🔗 Relation : chaque produit peut avoir plusieurs variantes.
+Chaque produit peut proposer plusieurs variantes.
 
----
+## `users`
 
-### `users` (profils personnalisés de Supabase Auth)
-| Champ       | Type         | Description                          |
-|-------------|--------------|--------------------------------------|
-| id          | uuid         | Référence à `auth.users.id`          |
-| email       | text         | Email utilisateur                    |
-| role        | text         | `client` ou `admin`                  |
-| created_at  | timestamp    | Date de création                     |
+- `id` (lié à `auth.users.id`)
+- `email`
+- `role` — `client` ou `admin`
+- `created_at`
 
-✅ Supabase Auth gère le compte, cette table enrichit le profil avec le rôle.
+Supabase Auth gère la connexion, cette table stocke le rôle.
 
----
+## `orders`
 
-### `orders`
-| Champ       | Type         | Description                          |
-|-------------|--------------|--------------------------------------|
-| id          | integer      | Identifiant de la commande           |
-| user_id     | uuid         | Référence vers `users.id`            |
-| created_at  | timestamp    | Date de la commande                  |
+- `id`, `user_id`
+- `created_at`
 
----
+## `order_items`
 
-### `order_items`
-| Champ         | Type     | Description                               |
-|---------------|----------|-------------------------------------------|
-| order_id      | integer  | Référence vers `orders.id`                |
-| item_variant_id | integer | Référence vers `item_variants.id`         |
-| quantity      | integer  | Quantité commandée                        |
-| customization | json     | Détail personnalisé (texte libre)         |
+- `order_id` + `item_variant_id` — clé composée
+- `quantity`
+- `customization` — champ JSON libre
 
-🔑 Clé composée : `(order_id, item_variant_id)`.
+## Sécurité (RLS)
 
----
+Les règles de Supabase limitent la lecture/écriture selon `auth.uid()` et le
+rôle de l’utilisateur.
 
-## 🔐 Sécurité Supabase (RLS)
-- Règles activées : accès en lecture/écriture restreint selon `auth.uid()`.
-- Lecture filtrée par rôle ou userId.
-- Gestion automatique des permissions via Supabase Policy Editor.
+## Fichiers SQL
 
----
-
-## 🗃️ Fichier SQL associé
-Fichier de création automatique exportable via `Table Editor` ou CLI Supabase.
-
-📁 Export prévu dans : `Database/bd.sql`
-📁 Exemple de seed : `Database/populate.sql`
+- `Database/bd.sql` — création des tables
+- `Database/populate.sql` — exemples de données

--- a/Docs/Pages.md
+++ b/Docs/Pages.md
@@ -1,55 +1,51 @@
-## 👤 Pages côté client (utilisateurs classiques)
+# Parcours des interfaces
+
+Ce document présente les principaux écrans de la boutique et de l'espace
+administrateur.
+
+## Côté boutique
 
 ### Accueil
-- Présentation de la boutique
-- Produits mis en avant
+Vitrine mettant en avant la boutique et quelques produits phares.
 
-### Catalogue / Boutique
-- Liste paginée des produits
-- Filtres par catégories, prix, etc.
+### Boutique
+Catalogue paginé avec filtres par catégorie, prix ou autres critères.
 
-### Page produit
-- Détails du produit (nom, description, prix, image, stock dispo, etc.)
-- Bouton « Ajouter au panier »
+### Fiche produit
+Détails d'un article : photos, description, prix et disponibilité. Un
+bouton permet d'ajouter le produit au panier.
 
 ### Panier
-Liste des produits sélectionnés
-Modifier quantité, supprimer un item
-Total, frais de livraison estimés
+Récapitulatif des articles choisis avec possibilité d'ajuster les
+quantités ou de retirer un article avant de passer commande.
 
-### Passer commande (Checkout)
-- Formulaire d’adresse, livraison, paiement
-- Récapitulatif de la commande
+### Commande
+Formulaire de livraison et de paiement suivi d'un récapitulatif.
 
-### Confirmation de commande
-- Merci pour votre achat + récap
-
+### Confirmation
+Message de remerciement avec le détail de la commande.
 
 ### À propos / Contact
-- Infos sur la boutique, formulaire de contact, liens réseaux sociaux
+Informations sur l'équipe, formulaire de contact et liens vers les réseaux
+sociaux.
 
-## 🔐 Pages côté admin
+## Espace administrateur
 
-Ces pages doivent être protégées par une authentification !
+Accessible uniquement aux comptes disposant des droits nécessaires.
 
-### Dashboard (Vue d'ensemble)
-- Nombre de commandes, ventes totales, produits en stock faible, etc.
+### Tableau de bord
+Vue d'ensemble : nombre de commandes, ventes, alertes de stock...
 
-### Gestion des produits
-- Liste des produits
-- Modifier / Supprimer un produit
-- Ajouter un nouveau produit
-- Formulaire avec image, titre, description, prix, stock
+### Produits
+Listing complet avec possibilité d'ajouter, modifier ou supprimer un
+article.
 
-### Gestion des commandes
-- Liste des commandes
-- Voir détails (produits commandés, date, statut, client, adresse)
-- Modifier le statut : en préparation, expédié, livré, annulé
-- Supprimer une commande si nécessaire
+### Commandes
+Suivi des commandes et mise à jour de leur statut (préparation, expédié,
+livré, annulé).
 
-### Gestion des stocks
-- Vue rapide des quantités disponibles
-- Modifier les quantités sans passer par la fiche produit complète
+### Stocks
+Modification rapide des quantités disponibles.
 
-### Connexion admin
-- Page de login (email + mot de passe)
+### Connexion
+Page de login dédiée aux administrateurs.

--- a/Docs/Roadmap.md
+++ b/Docs/Roadmap.md
@@ -1,6 +1,6 @@
 # 🛍️ Roadmap - Projet E-commerce
 
-Ce fichier contient les étapes de développement du projet, organisées par priorité. Tu peux cocher chaque case une fois une tâche terminée ✅
+Les grandes étapes prévues pour faire évoluer la boutique. Coche les cases au fur et à mesure ✅
 
 ---
 
@@ -85,4 +85,4 @@ Ce fichier contient les étapes de développement du projet, organisées par pri
 
 ---
 
-📅 Dernière mise à jour : `{{ À compléter manuellement }}`
+📅 Dernière mise à jour : 2025-09-09

--- a/README.md
+++ b/README.md
@@ -1,99 +1,28 @@
 # E-Commerce
-Projet vitrine d'une boutique en ligne utilisant **React** pour l'interface et **Supabase** pour la gestion des données et de l'authentification.
 
-## Sommaire :
-- [Liste des pages de l'application](./Docs/Pages.md)
-- [La partie FrontEnd du projet](./client/README.md)
-- [Schéma de la base de données](./Docs/BDD.md)
-- [Endpoints de l'API](./Docs/API.md)
-- [Architecture générale](./Docs/Architecture.md)
+Bienvenue sur le projet vitrine d'une boutique en ligne. Ce dépôt illustre
+une application complète bâtie avec **React** pour l'interface et
+**Supabase** pour l'authentification et la base de données.
 
-## Arborescence du projet
+## Découvrir le site
 
-```plaintext
-E-Commerce/
-├── client/                          # Frontend (React + Vite + Tailwind)
-│   ├── public/
-│   ├── src/
-│   │   ├── assets/                  # Logos, images, SVGs
-│   │   ├── components/             # Navbar, ProductCard, etc.
-│   │   ├── pages/                  # Home, Shop, Product, Cart, Admin...
-│   │   │   └── Admin/              # Dashboard, ProductForm, VariantForm
-│   │   ├── api/                    # Fonctions API via Supabase
-│   │   ├── auth/                   # AuthContext + hook + role check
-│   │   ├── context/                # CartContext (et autres si besoin)
-│   │   ├── utils/                  # formatPrice, role utils, etc.
-│   │   ├── supabase/               # Supabase client config
-│   │   │   └── client.js
-│   │   ├── App.jsx                 # Routes + Layout
-│   │   ├── index.js                # Entrée React
-│   │   └── styles/                 # main.css ou tailwind.css
-│   │
-│   ├── .env.local                  # SUPABASE_URL / SUPABASE_ANON_KEY
-│   └── vite.config.js
-│
-├── Database/                        # Scripts SQL
-│   ├── bd.sql                       # Création des tables
-│   └── populate.sql                 # Données de test
-│
-├── Docs/                           # Spécifications et maquettes
-│   ├── Assets/                      # Images utilisées dans la doc
-│   ├── API.md
-│   ├── BDD.md
-│   ├── Pages.md
-│   └── Architecture.md
-│
-└── README.md
+- **Catalogue** : parcourez les produits et leurs détails.
+- **Panier et commande** : ajoutez vos articles puis finalisez l'achat.
+- **Espace admin** : gérez produits, commandes et stocks.
 
+Un aperçu des pages disponibles est détaillé dans [Docs/Pages.md](./Docs/Pages.md).
+
+## Installation rapide
+
+```bash
+cd client
+npm install
+npm run dev
 ```
 
-## Installation
+Pour l'API et l'intégration Stripe, reportez‑vous au dossier `api/`.
 
-1. Installer les dépendances du front :
+## Aller plus loin
 
-   ```bash
-   cd client
-   npm install
-   ```
-
-2. (Backend) API Node/Express pour Stripe
-
-   ```bash
-   cd api
-   cp .env.example .env
-   # Renseignez SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, CLIENT_ORIGIN
-   npm install
-   npm run dev
-   ```
-
-3. Créer un fichier `.env.local` dans `client/` avec vos clés Supabase :
-
-   ```env
-   VITE_SUPABASE_URL=your-project-url
-   VITE_SUPABASE_ANON_KEY=your-anon-key
-   VITE_API_URL=http://localhost:3000
-   ```
-
-4. (Optionnel) Préparer une base Postgres locale :
-
-   ```bash
-   psql -U user -d ecommerce -f Database/bd.sql
-   psql -U user -d ecommerce -f Database/populate.sql
-   ```
-
-5. Lancer le serveur de développement :
-
-   ```bash
-   npm run dev
-   ```
-
-6. Webhook Stripe en local (via stripe-cli) :
-
-   ```bash
-   stripe listen --forward-to http://localhost:3000/api/stripe/webhook \
-     --events payment_intent.succeeded,payment_intent.payment_failed
-   ```
-
-
-
-
+Pour les schémas de base de données, l'architecture ou les endpoints,
+consultez le dossier [Docs](./Docs/).


### PR DESCRIPTION
## Summary
- simplify API route list with bullet overview
- streamline architecture and database docs to highlight React + Supabase setup
- update roadmap intro and timestamp

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c004f12fd8832fba80f75af18255df