### PR TITLE
Add item variants and user ratings to shop

### DIFF
--- a/Database/seed.sql
+++ b/Database/seed.sql
@@ -87,20 +87,28 @@ end $$;
 -- 3) Produits (items) + images
 ------------------------------------------------------------
 with c as (select id, name from public.categories)
-insert into public.items(name, description, price, image_url, category_id)
+insert into public.items(name, description, price, image_url, category_id, sizes, colors)
 values
   ('Chaussettes en laine', 'Chaussettes douillettes pour l’hiver', 12.00,
    'https://images.unsplash.com/photo-1519741497674-611481863552?w=1200&q=80&auto=format&fit=crop',
-   (select id from c where name='Vêtements')),
+   (select id from c where name='Vêtements'),
+   array['S','M','L'],
+   array['BLEU','ORANGE','VERT']),
   ('Mug en céramique', 'Mug artisanal peint à la main', 18.00,
    'https://images.unsplash.com/photo-1484659619207-9165d119dafe?w=1200&q=80&auto=format&fit=crop',
-   (select id from c where name='Maison')),
+   (select id from c where name='Maison'),
+   array['S','M','L'],
+   array['BLEU','ORANGE','VERT']),
   ('Bonnet tricoté', 'Bonnet chaud fait main', 15.00,
    'https://images.unsplash.com/photo-1603293552165-0e7d1226a9b6?w=1200&q=80&auto=format&fit=crop',
-   (select id from c where name='Vêtements')),
+   (select id from c where name='Vêtements'),
+   array['S','M','L'],
+   array['BLEU','ORANGE','VERT']),
   ('Plaid tissé main', 'Plaid doux et chaud', 35.00,
    'https://images.unsplash.com/photo-1582582621956-f11a44c1f36a?w=1200&q=80&auto=format&fit=crop',
-   (select id from c where name='Maison'))
+   (select id from c where name='Maison'),
+   array['S','M','L'],
+   array['BLEU','ORANGE','VERT'])
 on conflict do nothing;
 
 -- une image par item si absente

--- a/client/src/components/ItemCard.jsx
+++ b/client/src/components/ItemCard.jsx
@@ -9,7 +9,11 @@ export default function ItemCard({ item }) {
 
   const handleAddToCart = e => {
     e.preventDefault();
-    addItem(item);
+    addItem({
+      ...item,
+      selectedSize: item.sizes?.[0] || 'S',
+      selectedColor: item.colors?.[0] || 'BLEU',
+    });
   };
 
   return (

--- a/client/src/context/CartContext.jsx
+++ b/client/src/context/CartContext.jsx
@@ -15,22 +15,48 @@ export function CartProvider({ children }) {
 
   const addItem = item => {
     setCart(prev => {
-      const existing = prev.find(i => i.id === item.id);
+      const existing = prev.find(
+        i =>
+          i.id === item.id &&
+          i.selectedSize === item.selectedSize &&
+          i.selectedColor === item.selectedColor
+      );
       if (existing) {
-        return prev.map(i => (i.id === item.id ? { ...i, quantity: i.quantity + 1 } : i));
+        return prev.map(i =>
+          i.id === item.id &&
+          i.selectedSize === item.selectedSize &&
+          i.selectedColor === item.selectedColor
+            ? { ...i, quantity: i.quantity + 1 }
+            : i
+        );
       }
       return [...prev, { ...item, quantity: 1 }];
     });
   };
 
-  const removeItem = id => {
-    setCart(prev => prev.filter(i => i.id !== id));
+  const removeItem = item => {
+    setCart(prev =>
+      prev.filter(
+        i =>
+          !(
+            i.id === item.id &&
+            i.selectedSize === item.selectedSize &&
+            i.selectedColor === item.selectedColor
+          )
+      )
+    );
   };
 
-  const decreaseItem = id => {
+  const decreaseItem = item => {
     setCart(prev =>
       prev
-        .map(i => (i.id === id ? { ...i, quantity: i.quantity - 1 } : i))
+        .map(i =>
+          i.id === item.id &&
+          i.selectedSize === item.selectedSize &&
+          i.selectedColor === item.selectedColor
+            ? { ...i, quantity: i.quantity - 1 }
+            : i
+        )
         .filter(i => i.quantity > 0)
     );
   };

--- a/client/src/pages/Cart.jsx
+++ b/client/src/pages/Cart.jsx
@@ -32,19 +32,23 @@ const Cart = () => {
 
       <div className="cart-items">
         {cart.map(item => (
-          <div key={item.id} className="cart-item">
+          <div
+            key={`${item.id}-${item.selectedSize}-${item.selectedColor}`}
+            className="cart-item"
+          >
             <img src={item.item_images?.[0]?.image_url} alt={item.name} />
             <div className="item-details">
               <h3>{item.name}</h3>
               <p>{item.price}€</p>
+              <p>Taille: {item.selectedSize} | Couleur: {item.selectedColor}</p>
             </div>
             <div className="quantity-controls">
-              <button onClick={() => decreaseItem(item.id)}>-</button>
+              <button onClick={() => decreaseItem(item)}>-</button>
               <span>{item.quantity}</span>
               <button onClick={() => addItem(item)}>+</button>
             </div>
             <div className="item-total">{(item.price * item.quantity).toFixed(2)}€</div>
-            <button onClick={() => removeItem(item.id)} className="remove-btn">
+            <button onClick={() => removeItem(item)} className="remove-btn">
               Supprimer
             </button>
           </div>


### PR DESCRIPTION
## Summary
- store available sizes and colors for items and seed default values
- allow users to rate items and secure ratings with RLS policies
- update cart and product pages to choose variants and submit ratings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/ItemCard.jsx src/context/CartContext.jsx src/pages/Cart.jsx src/pages/ProductDetail.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68c12d674570832fbb97659e664c65d6