### PR TITLE
feature(items): Ajoute variantes sur les produits

### DIFF
--- a/Database/migrations/20241017_variants_overhaul.sql
+++ b/Database/migrations/20241017_variants_overhaul.sql
@@ -1,0 +1,119 @@
+-- Migration: normalize item variants structure and enforce data integrity
+-- Applies column rename, pricing constraints, uniqueness, and order_items linkage
+
+begin;
+
+-- 1) Rename legacy column "format" -> size if still present
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'item_variants'
+      AND column_name = 'format'
+  ) THEN
+    EXECUTE 'alter table public.item_variants rename column "format" to size';
+  END IF;
+END
+$$;
+
+-- 2) Ensure every variant has an explicit price >= 0
+update public.item_variants v
+set price = i.price
+from public.items i
+where v.item_id = i.id
+  and v.price is null;
+
+alter table public.item_variants drop constraint if exists item_variants_price_check;
+alter table public.item_variants alter column price set not null;
+alter table public.item_variants add constraint item_variants_price_check check (price >= 0);
+
+-- 3) Create a fallback variant per item if none exists (needed for future constraints)
+insert into public.item_variants (item_id, sku, color, size, stock, price)
+select i.id,
+       concat('auto-', i.id),
+       null,
+       null,
+       0,
+       i.price
+from public.items i
+where not exists (
+  select 1
+  from public.item_variants v
+  where v.item_id = i.id
+);
+
+-- 4) Enforce uniqueness of (item_id, size, color) treating null as ''
+create unique index if not exists ux_item_variants_combo
+  on public.item_variants (item_id, coalesce(size, ''), coalesce(color, ''));
+create index if not exists idx_item_variants_item_size_color
+  on public.item_variants (item_id, size, color);
+
+-- 5) Attach order items to an existing variant (prefer the cheapest)
+update public.order_items oi
+set variant_id = picked.variant_id
+from lateral (
+  select v.id as variant_id
+  from public.item_variants v
+  where v.item_id = oi.item_id
+  order by v.price asc, v.id asc
+  limit 1
+) as picked
+where oi.variant_id is null;
+
+-- 6) Strengthen referential integrity on order_items.variant_id
+alter table public.order_items alter column variant_id set not null;
+
+-- The FK is still "on delete set null" from legacy definitions.
+-- Replace it with "on delete restrict" now that the column is NOT NULL.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.order_items'::regclass
+      AND confrelid = 'public.item_variants'::regclass
+      AND contype = 'f'
+  ) THEN
+    ALTER TABLE public.order_items
+      DROP CONSTRAINT IF EXISTS order_items_variant_id_fkey;
+  END IF;
+END
+$$;
+
+alter table public.order_items
+  add constraint order_items_variant_id_fkey
+  foreign key (variant_id) references public.item_variants(id) on delete restrict;
+
+-- 7) Ensure the variant referenced by an order_item belongs to the same item
+create or replace function public.ensure_order_item_variant_consistency()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.variant_id is null then
+    return new;
+  end if;
+
+  if not exists (
+    select 1
+    from public.item_variants v
+    where v.id = new.variant_id
+      and v.item_id = new.item_id
+  ) then
+    raise exception using
+      errcode = '23503',
+      message = format('Variant %s does not belong to item %s', new.variant_id, new.item_id);
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_order_items_variant_consistency on public.order_items;
+create trigger trg_order_items_variant_consistency
+before insert or update on public.order_items
+for each row execute function public.ensure_order_item_variant_consistency();
+
+commit;

--- a/Database/scripts/backfill_variants_from_items.sql
+++ b/Database/scripts/backfill_variants_from_items.sql
@@ -1,0 +1,90 @@
+-- Backfill script: create item variants from items.sizes/colors arrays
+-- Run after 20241017_variants_overhaul.sql to populate normalized data
+
+begin;
+
+-- Helper CTE to expand size/color combinations (gracefully handles null/empty arrays)
+with expanded as (
+  select distinct
+         i.id as item_id,
+         nullif(trim(sz), '') as size,
+         nullif(trim(cl), '') as color,
+         i.price as base_price
+  from public.items i
+  left join lateral unnest(
+    case
+      when i.sizes is null or array_length(i.sizes, 1) = 0 then array[null::text]
+      else i.sizes
+    end
+  ) as s(sz) on true
+  left join lateral unnest(
+    case
+      when i.colors is null or array_length(i.colors, 1) = 0 then array[null::text]
+      else i.colors
+    end
+  ) as c(cl) on true
+)
+insert into public.item_variants (item_id, size, color, price, stock, sku)
+select e.item_id,
+       e.size,
+       e.color,
+       e.base_price,
+       0,
+       concat('sku-', e.item_id, '-', coalesce(e.size, '_'), '-', coalesce(e.color, '_'))
+from expanded e
+where not exists (
+  select 1
+  from public.item_variants v
+  where v.item_id = e.item_id
+    and coalesce(v.size, '') = coalesce(e.size, '')
+    and coalesce(v.color, '') = coalesce(e.color, '')
+);
+
+-- Update each item price to reflect the cheapest variant
+with min_prices as (
+  select item_id, min(price) as min_price
+  from public.item_variants
+  group by item_id
+)
+update public.items i
+set price = m.min_price
+from min_prices m
+where i.id = m.item_id
+  and i.price <> m.min_price;
+
+-- Reassign any fallback variants created during migration to the best available real variant
+with fallback as (
+  select v.id, v.item_id
+  from public.item_variants v
+  where v.sku like 'auto-%'
+),
+preferred as (
+  select fb.id as fallback_id,
+         best.id as preferred_id
+  from fallback fb
+  join lateral (
+    select v.id
+    from public.item_variants v
+    where v.item_id = fb.item_id
+      and v.sku not like 'auto-%'
+    order by v.price asc, v.id asc
+    limit 1
+  ) as best on true
+)
+update public.order_items oi
+set variant_id = p.preferred_id
+from preferred p
+where oi.variant_id = p.fallback_id;
+
+-- Remove fallback variants when a proper variant exists
+delete from public.item_variants v
+where v.sku like 'auto-%'
+  and exists (
+    select 1
+    from public.item_variants other
+    where other.item_id = v.item_id
+      and other.id <> v.id
+      and other.sku not like 'auto-%'
+  );
+
+commit;

--- a/Docs/BDD.md
+++ b/Docs/BDD.md
@@ -14,9 +14,9 @@ Aperçu des tables principales utilisées par la boutique Supabase.
 ## `item_variants`
 
 - `id`, `item_id`
-- `color`, `format`
-- `stock` — quantité disponible
-- `extra_price` — surcoût éventuel
+- `color`, `size`
+- `stock` — quantité disponible (>= 0)
+- `price` — prix variant (obligatoire, en euros)
 
 Chaque produit peut proposer plusieurs variantes.
 
@@ -49,3 +49,5 @@ rôle de l’utilisateur.
 
 - `Database/bd.sql` — création des tables
 - `Database/populate.sql` — exemples de données
+- `Database/migrations/20241017_variants_overhaul.sql` — migration renommage taille/prix et contraintes
+- `Database/scripts/backfill_variants_from_items.sql` — génération de variantes depuis `items.sizes/colors`

--- a/Docs/Roadmap.md
+++ b/Docs/Roadmap.md
@@ -48,7 +48,7 @@ Les grandes étapes prévues pour faire évoluer la boutique. Coche les cases au
 ### 📋 Interface Admin
 - [ ] Liste des produits (pagination, actions CRUD)
 - [ ] Formulaire ajout / édition produit
-- [ ] Gestion des variantes (formats, prix, stock)
+- [ ] Gestion des variantes (tailles, prix, stock)
 - [ ] Liste des commandes (filtrage par statut)
 
 ### 🔐 Supabase RLS

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,1027 @@
+{
+  "name": "api",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "api",
+      "version": "0.1.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.51.0",
+        "cors": "^2.8.5",
+        "express": "^4.19.2",
+        "nodemailer": "^7.0.6",
+        "stripe": "^16.7.0"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.6.tgz",
+      "integrity": "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
+      "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -11,7 +11,7 @@
     "@supabase/supabase-js": "^2.51.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
+    "nodemailer": "^7.0.6",
     "stripe": "^16.7.0"
   }
 }
-

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -89,14 +89,17 @@ function normalizeCartItems(rawItems) {
   return rawItems
     .map(i => ({
       item_id: i.item_id || i.id || i.itemId,
-      quantity: Number(i.quantity) || 1,
-      variant_id: i.variant_id || i.variantId || null,
+      quantity: Math.max(1, Number(i.quantity) || 1),
+      variant_id: i.variant_id != null ? Number(i.variant_id) : i.variantId != null ? Number(i.variantId) : null,
     }))
     .filter(i => i.item_id)
 }
 
-async function computeAmountCents(cartItems) {
-  if (!cartItems.length) return 0
+async function gatherCartPricing(cartItems) {
+  if (!cartItems.length) {
+    return { totalCents: 0, itemsById: new Map(), variantsById: new Map() }
+  }
+
   const itemIds = [...new Set(cartItems.map(i => i.item_id))]
   const variantIds = [...new Set(cartItems.map(i => i.variant_id).filter(Boolean))]
 
@@ -111,21 +114,26 @@ async function computeAmountCents(cartItems) {
   if (variantIds.length) {
     const { data: variants, error: variantsError } = await supabase
       .from('item_variants')
-      .select('id, item_id, price')
+      .select('id, item_id, price, stock')
       .in('id', variantIds)
     if (variantsError) throw variantsError
-    variantMap = new Map(variants.map(v => [v.id, { item_id: v.item_id, price: v.price != null ? Number(v.price) : null }]))
+    variantMap = new Map(
+      variants.map(v => [v.id, { item_id: v.item_id, price: Number(v.price), stock: v.stock ?? 0 }])
+    )
   }
 
   const total = cartItems.reduce((sum, it) => {
     const basePrice = itemMap.get(it.item_id) || 0
     const variant = it.variant_id ? variantMap.get(it.variant_id) : null
-    const price = variant?.price != null ? variant.price : basePrice
+    const price = variant ? variant.price : basePrice
     return sum + price * it.quantity
   }, 0)
 
-  // Convert euros to cents safely
-  return Math.max(0, Math.round(total * 100))
+  return {
+    totalCents: Math.max(0, Math.round(total * 100)),
+    itemsById: itemMap,
+    variantsById: variantMap,
+  }
 }
 
 app.post('/api/checkout', async (req, res) => {
@@ -137,8 +145,25 @@ app.post('/api/checkout', async (req, res) => {
     const cartItems = normalizeCartItems(req.body.cartItems)
     if (!cartItems.length) return res.status(400).json({ error: 'Cart is empty' })
 
-    const amount = await computeAmountCents(cartItems)
+    if (cartItems.some(ci => !ci.variant_id)) {
+      return res.status(400).json({ error: 'Chaque article doit inclure un variant_id.' })
+    }
+
+    const { totalCents: amount, variantsById } = await gatherCartPricing(cartItems)
     if (amount <= 0) return res.status(400).json({ error: 'Invalid amount' })
+
+    for (const item of cartItems) {
+      const variant = variantsById.get(item.variant_id)
+      if (!variant) {
+        return res.status(400).json({ error: `Variant ${item.variant_id} introuvable` })
+      }
+      if (variant.item_id !== item.item_id) {
+        return res.status(400).json({ error: 'Variant et produit incompatibles' })
+      }
+      if (variant.stock != null && variant.stock < item.quantity) {
+        return res.status(400).json({ error: 'Stock insuffisant pour un des variants' })
+      }
+    }
 
     // Create order in pending
     const { data: order, error: orderErr } = await supabase
@@ -153,7 +178,8 @@ app.post('/api/checkout', async (req, res) => {
       order_id: order.id,
       item_id: ci.item_id,
       quantity: ci.quantity,
-      variant_id: ci.variant_id || null,
+      variant_id: ci.variant_id,
+      unit_price: variantsById.get(ci.variant_id)?.price ?? 0,
     }))
     const { error: oiErr } = await supabase.from('order_items').insert(orderItemsPayload)
     if (oiErr) throw oiErr
@@ -179,4 +205,3 @@ app.post('/api/checkout', async (req, res) => {
 app.listen(PORT, () => {
   console.log(`[api] listening on :${PORT}`)
 })
-

--- a/client/src/components/Admin/ProductManager.jsx
+++ b/client/src/components/Admin/ProductManager.jsx
@@ -3,6 +3,35 @@ import { supabase } from '../../supabase/supabaseClient';
 
 export const TABLE_ITEMS = 'items';
 const TABLE_CATEGORIES = 'categories';
+const TABLE_VARIANTS = 'item_variants';
+
+const createEmptyVariant = () => ({
+  id: null,
+  size: '',
+  color: '',
+  price: '',
+  stock: 0,
+  sku: '',
+});
+
+const sanitizeText = value => (value || '').trim();
+
+const slugify = value =>
+  sanitizeText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
+const randomSuffix = () =>
+  typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID().slice(0, 8)
+    : Math.random().toString(36).slice(2, 8).toUpperCase();
+
+const buildSku = (itemId, variant) => {
+  const sizeSlug = slugify(variant.size) || 'std';
+  const colorSlug = slugify(variant.color || '') || 'def';
+  return `SKU-${itemId}-${sizeSlug}-${colorSlug}-${randomSuffix()}`.toUpperCase();
+};
 
 export default function ProductAdmin() {
   const [products, setProducts] = useState([]);
@@ -15,29 +44,21 @@ export default function ProductAdmin() {
 
   const [form, setForm] = useState({
     name: '',
-    price: '',
     description: '',
     category_id: '',
-    sizes: ['S', 'M', 'L'],
-    colors: ['BLEU', 'ORANGE', 'VERT'],
   });
 
-  const [sizeInput, setSizeInput] = useState('');
-  const [colorInput, setColorInput] = useState('');
+  const [variants, setVariants] = useState([createEmptyVariant()]);
   const [newImages, setNewImages] = useState([]); // File[]
   const [imagePreviews, setImagePreviews] = useState([]); // local URL previews
 
   const resetForm = () => {
     setForm({
       name: '',
-      price: '',
       description: '',
       category_id: '',
-      sizes: ['S', 'M', 'L'],
-      colors: ['BLEU', 'ORANGE', 'VERT'],
     });
-    setSizeInput('');
-    setColorInput('');
+    setVariants([createEmptyVariant()]);
     setEditingId(null);
     setNewImages([]);
     setImagePreviews([]);
@@ -53,7 +74,8 @@ export default function ProductAdmin() {
           `
           id, name, price, description, category_id, sizes, colors,
           item_images ( id, image_url ),
-          categories ( id, name )
+          categories ( id, name ),
+          item_variants ( id, size, color, price, stock, sku )
         `
         )
         .order('id', { ascending: false });
@@ -80,26 +102,22 @@ export default function ProductAdmin() {
 
   const handleChange = e => {
     const { name, value } = e.target;
-    setForm(prev => ({ ...prev, [name]: name === 'price' ? value : value }));
+    setForm(prev => ({ ...prev, [name]: value }));
   };
 
-  const addSize = () => {
-    const v = (sizeInput || '').trim();
-    if (!v) return;
-    setForm(prev => ({ ...prev, sizes: Array.from(new Set([...(prev.sizes || []), v])) }));
-    setSizeInput('');
+  const addVariantRow = () => {
+    setVariants(prev => [...prev, createEmptyVariant()]);
   };
-  const removeSize = value => {
-    setForm(prev => ({ ...prev, sizes: (prev.sizes || []).filter(s => s !== value) }));
+
+  const updateVariantField = (index, field, value) => {
+    setVariants(prev => prev.map((variant, idx) => (idx === index ? { ...variant, [field]: value } : variant)));
   };
-  const addColor = () => {
-    const v = (colorInput || '').trim();
-    if (!v) return;
-    setForm(prev => ({ ...prev, colors: Array.from(new Set([...(prev.colors || []), v])) }));
-    setColorInput('');
-  };
-  const removeColor = value => {
-    setForm(prev => ({ ...prev, colors: (prev.colors || []).filter(c => c !== value) }));
+
+  const removeVariantRow = index => {
+    setVariants(prev => {
+      if (prev.length === 1) return [createEmptyVariant()];
+      return prev.filter((_, idx) => idx !== index);
+    });
   };
 
   const onFilesSelected = files => {
@@ -146,37 +164,133 @@ export default function ProductAdmin() {
     return imageUrl;
   };
 
+  const minVariantPrice = useMemo(() => {
+    const prices = variants
+      .map(v => parseFloat(String(v.price).replace(',', '.')))
+      .filter(v => !Number.isNaN(v) && v >= 0);
+    if (!prices.length) return null;
+    return Math.min(...prices);
+  }, [variants]);
+
+  const validateVariants = () => {
+    const errors = [];
+    const combos = new Set();
+    const cleaned = variants.map((variant, index) => {
+      const size = sanitizeText(variant.size);
+      const colorText = sanitizeText(variant.color);
+      const color = colorText || null;
+      const price = parseFloat(String(variant.price).replace(',', '.'));
+      const stock = Math.max(0, parseInt(variant.stock, 10) || 0);
+
+      if (!size) errors.push(`Variante #${index + 1}: la taille est requise.`);
+      if (Number.isNaN(price)) errors.push(`Variante #${index + 1}: prix invalide.`);
+      if (!Number.isNaN(price) && price < 0) errors.push(`Variante #${index + 1}: le prix doit être positif.`);
+
+      const key = `${size}::${color || ''}`;
+      if (size && !Number.isNaN(price)) {
+        if (combos.has(key)) {
+          errors.push(`Variante #${index + 1}: combinaison taille/couleur déjà utilisée.`);
+        } else {
+          combos.add(key);
+        }
+      }
+
+      return {
+        ...variant,
+        size,
+        color,
+        price,
+        stock,
+        index,
+      };
+    });
+
+    const valid = cleaned.filter(v => v.size && !Number.isNaN(v.price) && v.price >= 0);
+    if (!valid.length) errors.push('Au moins une variante valide est requise.');
+
+    return { errors, validVariants: valid };
+  };
+
   const handleSubmit = async e => {
     e.preventDefault();
     try {
-      const payload = {
-        name: form.name,
-        price: parseFloat(String(form.price).replace(',', '.')) || 0,
-        description: form.description || null,
-        category_id: form.category_id ? Number(form.category_id) : null,
-        sizes: form.sizes || [],
-        colors: form.colors || [],
-      };
-
-      if (!payload.name || isNaN(payload.price)) {
-        alert('Nom et prix sont requis.');
+      const trimmedName = sanitizeText(form.name);
+      if (!trimmedName) {
+        alert('Le nom du produit est requis.');
         return;
       }
 
+      const { errors: variantErrors, validVariants } = validateVariants();
+      if (variantErrors.length) {
+        alert(variantErrors.join('\n'));
+        return;
+      }
+
+      const minPrice = Math.min(...validVariants.map(v => v.price));
+      const uniqueSizes = Array.from(new Set(validVariants.map(v => v.size))).sort();
+      const uniqueColors = Array.from(new Set(validVariants.map(v => v.color).filter(Boolean))).sort();
+
+      const itemPayload = {
+        name: trimmedName,
+        description: sanitizeText(form.description) || null,
+        category_id: form.category_id ? Number(form.category_id) : null,
+        price: minPrice,
+        sizes: uniqueSizes,
+        colors: uniqueColors,
+      };
+
+      let itemId = editingId;
       if (editingId) {
-        const { error } = await supabase.from(TABLE_ITEMS).update(payload).eq('id', editingId);
+        const { error } = await supabase.from(TABLE_ITEMS).update(itemPayload).eq('id', editingId);
         if (error) throw error;
-        // Upload nouvelles images si présentes
-        if (newImages.length) {
-          await Promise.all(newImages.map(f => uploadImage(f, editingId)));
-        }
       } else {
-        const { data, error } = await supabase.from(TABLE_ITEMS).insert([payload]).select().single();
+        const { data, error } = await supabase.from(TABLE_ITEMS).insert([itemPayload]).select('id').single();
         if (error) throw error;
-        const itemId = data.id;
-        if (newImages.length) {
-          await Promise.all(newImages.map(f => uploadImage(f, itemId)));
-        }
+        itemId = data.id;
+      }
+
+      // Fetch existing variants to detect deletions
+      const { data: existingVariants, error: existingError } = await supabase
+        .from(TABLE_VARIANTS)
+        .select('id')
+        .eq('item_id', itemId);
+      if (existingError) throw existingError;
+      const existingIds = (existingVariants || []).map(v => v.id);
+
+      const variantsPayload = validVariants.map((variant, idx) => {
+        const payload = {
+          item_id: itemId,
+          size: variant.size,
+          color: variant.color,
+          price: variant.price,
+          stock: variant.stock,
+          sku: variant.sku || buildSku(itemId, variant),
+        };
+        if (variant.id) payload.id = variant.id;
+        return payload;
+      });
+
+      const { error: upsertError } = await supabase
+        .from(TABLE_VARIANTS)
+        .upsert(variantsPayload, { onConflict: 'id' });
+      if (upsertError) throw upsertError;
+
+      const keepIds = variantsPayload.filter(v => v.id).map(v => v.id);
+      const toDelete = existingIds.filter(id => !keepIds.includes(id));
+      if (toDelete.length) {
+        const { error: deleteError } = await supabase.from(TABLE_VARIANTS).delete().in('id', toDelete);
+        if (deleteError) throw deleteError;
+      }
+
+      // Assure que le prix min est bien répercuté
+      const { error: priceError } = await supabase
+        .from(TABLE_ITEMS)
+        .update({ price: minPrice, sizes: uniqueSizes, colors: uniqueColors })
+        .eq('id', itemId);
+      if (priceError) throw priceError;
+
+      if (newImages.length) {
+        await Promise.all(newImages.map(f => uploadImage(f, itemId)));
       }
 
       resetForm();
@@ -199,18 +313,37 @@ export default function ProductAdmin() {
     }
   };
 
-  const handleEdit = product => {
+  const handleEdit = async product => {
     setEditingId(product.id);
     setForm({
       name: product.name || '',
-      price: product.price ?? '',
       description: product.description || '',
       category_id: product.category_id || '',
-      sizes: product.sizes || [],
-      colors: product.colors || [],
     });
     setNewImages([]);
     setImagePreviews([]);
+
+    const { data, error } = await supabase
+      .from(TABLE_VARIANTS)
+      .select('id, size, color, price, stock, sku')
+      .eq('item_id', product.id)
+      .order('price', { ascending: true })
+      .order('id', { ascending: true });
+
+    if (!error) {
+      const mapped = (data || []).map(v => ({
+        id: v.id,
+        size: v.size || '',
+        color: v.color || '',
+        price: v.price != null ? Number(v.price).toFixed(2) : '',
+        stock: v.stock ?? 0,
+        sku: v.sku || '',
+      }));
+      setVariants(mapped.length ? mapped : [createEmptyVariant()]);
+    } else {
+      console.error('Erreur chargement variantes:', error.message);
+      setVariants([createEmptyVariant()]);
+    }
   };
 
   const removeNewImage = idx => {
@@ -220,16 +353,13 @@ export default function ProductAdmin() {
 
   const deleteExistingImage = async (productId, image) => {
     try {
-      // Supprimer le fichier du bucket si possible (extraction du chemin)
       const marker = '/product-images/';
       const idx = image.image_url.indexOf(marker);
       if (idx !== -1) {
         const path = image.image_url.substring(idx + marker.length);
         await supabase.storage.from('product-images').remove([path]);
       }
-      // Supprimer l'entrée BD
       await supabase.from('item_images').delete().eq('id', image.id);
-      // Mise à jour locale
       setProducts(prev =>
         prev.map(p =>
           p.id === productId
@@ -255,16 +385,10 @@ export default function ProductAdmin() {
       <form onSubmit={handleSubmit} className="product-form" style={{ display: 'grid', gap: '10px' }}>
         <div style={{ display: 'grid', gap: '8px', gridTemplateColumns: '1fr 180px' }}>
           <input name="name" value={form.name} onChange={handleChange} placeholder="Titre" required />
-          <input
-            name="price"
-            type="number"
-            step="0.01"
-            inputMode="decimal"
-            value={form.price}
-            onChange={handleChange}
-            placeholder="Prix (€)"
-            required
-          />
+          <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+            <span style={{ fontSize: 12, color: '#4b5563' }}>Prix min (auto)</span>
+            <strong>{minVariantPrice != null ? `${minVariantPrice.toFixed(2)} €` : '—'}</strong>
+          </div>
         </div>
 
         <textarea
@@ -283,55 +407,76 @@ export default function ProductAdmin() {
               </option>
             ))}
           </select>
-
-          <div>
-            <div style={{ display: 'flex', gap: 6 }}>
-              <input
-                value={sizeInput}
-                onChange={e => setSizeInput(e.target.value)}
-                onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), addSize())}
-                placeholder="Ajouter une taille (Entrée)"
-              />
-              <button type="button" onClick={addSize}>
-                +
-              </button>
-            </div>
-            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 6 }}>
-              {(form.sizes || []).map(s => (
-                <span key={s} style={{ padding: '4px 8px', background: '#eef0f3', borderRadius: 8 }}>
-                  {s}{' '}
-                  <button type="button" onClick={() => removeSize(s)} aria-label={`Retirer ${s}`}>
-                    ×
-                  </button>
-                </span>
-              ))}
-            </div>
-          </div>
         </div>
 
-        <div>
-          <div style={{ display: 'flex', gap: 6 }}>
-            <input
-              value={colorInput}
-              onChange={e => setColorInput(e.target.value)}
-              onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), addColor())}
-              placeholder="Ajouter une couleur (Entrée)"
-            />
-            <button type="button" onClick={addColor}>
-              +
+        <section className="variant-editor" style={{ border: '1px solid #e2e8f0', borderRadius: 8, padding: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+            <h3 style={{ margin: 0 }}>Variantes</h3>
+            <button type="button" onClick={addVariantRow} className="btn btn-outline">
+              + Ajouter une variante
             </button>
           </div>
-          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 6 }}>
-            {(form.colors || []).map(c => (
-              <span key={c} style={{ padding: '4px 8px', background: '#eef0f3', borderRadius: 8 }}>
-                {c}{' '}
-                <button type="button" onClick={() => removeColor(c)} aria-label={`Retirer ${c}`}>
-                  ×
-                </button>
-              </span>
-            ))}
+          <div style={{ overflowX: 'auto' }}>
+            <table className="variant-table">
+              <thead>
+                <tr>
+                  <th>Taille</th>
+                  <th>Couleur</th>
+                  <th>Prix (€)</th>
+                  <th>Stock</th>
+                  <th>SKU</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {variants.map((variant, index) => (
+                  <tr key={variant.id ?? `new-${index}`}>
+                    <td>
+                      <input
+                        value={variant.size}
+                        onChange={e => updateVariantField(index, 'size', e.target.value)}
+                        placeholder="Ex: S, M, L"
+                        required
+                      />
+                    </td>
+                    <td>
+                      <input
+                        value={variant.color}
+                        onChange={e => updateVariantField(index, 'color', e.target.value)}
+                        placeholder="Couleur"
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="number"
+                        step="0.01"
+                        value={variant.price}
+                        onChange={e => updateVariantField(index, 'price', e.target.value)}
+                        placeholder="Prix"
+                        required
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="number"
+                        min={0}
+                        value={variant.stock}
+                        onChange={e => updateVariantField(index, 'stock', e.target.value)}
+                        placeholder="Stock"
+                      />
+                    </td>
+                    <td>{variant.sku || 'Auto'}</td>
+                    <td>
+                      <button type="button" onClick={() => removeVariantRow(index)} className="btn btn-outline">
+                        Retirer
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
-        </div>
+        </section>
 
         <div
           onDrop={onDrop}
@@ -401,10 +546,9 @@ export default function ProductAdmin() {
                 <th>#</th>
                 <th>Image</th>
                 <th>Titre</th>
-                <th>Prix</th>
+                <th>Prix (min)</th>
                 <th>Catégorie</th>
-                <th>Tailles</th>
-                <th>Couleurs</th>
+                <th>Variantes</th>
                 <th>Images</th>
                 <th>Actions</th>
               </tr>
@@ -427,8 +571,21 @@ export default function ProductAdmin() {
                   <td>{p.name}</td>
                   <td>{Number(p.price).toFixed(2)}€</td>
                   <td>{categoryName(p.category_id)}</td>
-                  <td>{(p.sizes || []).join(', ')}</td>
-                  <td>{(p.colors || []).join(', ')}</td>
+                  <td>
+                    {(p.item_variants || []).length ? (
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                        {p.item_variants.slice(0, 3).map(v => (
+                          <span key={v.id}>
+                            {v.size}
+                            {v.color ? ` / ${v.color}` : ''} — {Number(v.price).toFixed(2)}€
+                          </span>
+                        ))}
+                        {p.item_variants.length > 3 && <span>… (+{p.item_variants.length - 3})</span>}
+                      </div>
+                    ) : (
+                      <span style={{ color: '#9ca3af' }}>—</span>
+                    )}
+                  </td>
                   <td>
                     <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
                       {(p.item_images || []).map(img => (

--- a/client/src/components/MiniItemCard.jsx
+++ b/client/src/components/MiniItemCard.jsx
@@ -5,14 +5,14 @@ import { CartContext } from '../context/CartContext';
 export default function MiniItemCard({ item }) {
   const { addItem } = useContext(CartContext);
   const imageUrl = item?.item_images?.[0]?.image_url;
+  const variants = item?.item_variants || [];
+  const preferredVariant = variants.find(v => (v.stock ?? 0) > 0) || variants[0] || null;
+  const displayPrice = item?.price != null ? Number(item.price) : preferredVariant?.price != null ? Number(preferredVariant.price) : 0;
 
   const handleAdd = e => {
     e.preventDefault();
-    addItem({
-      ...item,
-      selectedSize: item.sizes?.[0] || 'S',
-      selectedColor: item.colors?.[0] || 'BLEU',
-    });
+    if (!preferredVariant) return;
+    addItem({ item, variant: preferredVariant });
   };
 
   return (
@@ -27,13 +27,18 @@ export default function MiniItemCard({ item }) {
       <div className="mini-card__body">
         <div className="mini-card__info">
           <h3 className="mini-card__title" title={item?.name}>{item?.name}</h3>
-          <div className="mini-card__price">{item?.price?.toLocaleString()} €</div>
+          <div className="mini-card__price">{displayPrice.toFixed(2)} €</div>
         </div>
         <div className="mini-card__actions">
           <Link to={`/item/${item?.id}`} className="btn btn--ghost" aria-label="Voir le détail du produit">
             En savoir plus
           </Link>
-          <button className="btn btn--primary" onClick={handleAdd} aria-label="Ajouter au panier">
+          <button
+            className="btn btn--primary"
+            onClick={handleAdd}
+            aria-label="Ajouter au panier"
+            disabled={!preferredVariant || (preferredVariant.stock != null && preferredVariant.stock <= 0)}
+          >
             Ajouter
           </button>
         </div>
@@ -41,4 +46,3 @@ export default function MiniItemCard({ item }) {
     </div>
   );
 }
-

--- a/client/src/components/Stripe.jsx
+++ b/client/src/components/Stripe.jsx
@@ -19,7 +19,7 @@ const StripeCheckout = () => {
   // Calculer le total du panier
   const calculateTotal = () => {
     return cart.reduce((total, item) => {
-      return total + item.price * item.quantity;
+      return total + (Number(item.unit_price) || 0) * item.quantity;
     }, 0);
   };
 
@@ -38,7 +38,11 @@ const StripeCheckout = () => {
       }
 
       const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-      const minimalCart = cart.map(i => ({ item_id: i.id, quantity: i.quantity, variant_id: i.variant_id }));
+      const minimalCart = cart.map(i => ({
+        item_id: i.itemId || i.id,
+        quantity: i.quantity,
+        variant_id: i.variant_id ?? i.variantId,
+      }));
       const response = await fetch(`${apiUrl}/api/checkout`, {
         method: 'POST',
         headers: {
@@ -126,13 +130,16 @@ const StripeCheckout = () => {
       {/* Résumé de la commande */}
       <div className="order-summary">
         <h3>Résumé de votre commande</h3>
-        {cart.map(item => (
-          <div key={item.id} className="order-item">
+        {cart.map(item => {
+          const unit = Number(item.unit_price) || 0;
+          return (
+            <div key={item.variantId} className="order-item">
             <span className="item-name">{item.name}</span>
             <span className="item-quantity">{item.quantity}x</span>
-            <span className="item-total">{(item.price * item.quantity).toFixed(2)}€</span>
+            <span className="item-total">{(unit * item.quantity).toFixed(2)}€</span>
           </div>
-        ))}
+          );
+        })}
         <div className="order-total">
           <strong>Total: {calculateTotal().toFixed(2)}€</strong>
         </div>

--- a/client/src/context/CartContext.jsx
+++ b/client/src/context/CartContext.jsx
@@ -1,63 +1,117 @@
 import { createContext, useEffect, useState } from 'react';
 
-// ✅ ne pas exporter ce hook
 const CartContext = createContext();
 
-export function CartProvider({ children }) {
-  const [cart, setCart] = useState(() => {
+const loadInitialCart = () => {
+  try {
     const stored = localStorage.getItem('cart');
-    return stored ? JSON.parse(stored) : [];
-  });
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(item => item && (item.variantId != null || item.variant_id != null))
+      .map(item => ({
+        ...item,
+        variantId: item.variantId ?? item.variant_id,
+        variant_id: item.variantId ?? item.variant_id,
+        unit_price: Number(item.unit_price ?? item.price ?? 0),
+        quantity: Math.max(1, Number(item.quantity) || 1),
+      }));
+  } catch (err) {
+    console.warn('Unable to load cart from storage:', err);
+    return [];
+  }
+};
+
+export function CartProvider({ children }) {
+  const [cart, setCart] = useState(loadInitialCart);
 
   useEffect(() => {
     localStorage.setItem('cart', JSON.stringify(cart));
   }, [cart]);
 
-  const addItem = item => {
+  const addItem = payload => {
+    if (!payload) return;
+
     setCart(prev => {
-      const existing = prev.find(
-        i =>
-          i.id === item.id &&
-          i.selectedSize === item.selectedSize &&
-          i.selectedColor === item.selectedColor
-      );
-      if (existing) {
-        return prev.map(i =>
-          i.id === item.id &&
-          i.selectedSize === item.selectedSize &&
-          i.selectedColor === item.selectedColor
-            ? { ...i, quantity: i.quantity + 1 }
-            : i
-        );
+      // New addition with product + variant data
+      if (payload.item && payload.variant) {
+        const { item, variant } = payload;
+        const quantityToAdd = Math.max(1, Number(payload.quantity) || 1);
+        const variantId = variant.id;
+        if (!item?.id || !variantId) return prev;
+        const stock = variant.stock ?? null;
+
+        const index = prev.findIndex(line => line.variantId === variantId);
+        if (index !== -1) {
+          const existing = prev[index];
+          const nextQuantity = existing.quantity + quantityToAdd;
+          if (stock != null && nextQuantity > stock) {
+            return prev;
+          }
+          const updated = [...prev];
+          updated[index] = { ...existing, quantity: nextQuantity, stock };
+          return updated;
+        }
+
+        if (stock != null && quantityToAdd > stock) {
+          return prev;
+        }
+
+        const newLine = {
+          id: item.id,
+          itemId: item.id,
+          variantId,
+          variant_id: variantId,
+          name: item.name,
+          unit_price: Number(variant.price),
+          quantity: quantityToAdd,
+          size: variant.size,
+          color: variant.color || null,
+          stock,
+          image_url: item.item_images?.[0]?.image_url || item.image_url || null,
+        };
+        return [...prev, newLine];
       }
-      return [...prev, { ...item, quantity: 1 }];
+
+      // Increment existing line by variant id
+      const variantId = payload.variantId ?? payload.variant_id;
+      if (variantId == null) {
+        return prev;
+      }
+
+      let changed = false;
+      const next = prev.map(line => {
+        if (line.variantId !== variantId) return line;
+        const stock = line.stock ?? null;
+        const nextQuantity = line.quantity + 1;
+        if (stock != null && nextQuantity > stock) {
+          return line;
+        }
+        changed = true;
+        return { ...line, quantity: nextQuantity };
+      });
+      return changed ? next : prev;
     });
   };
 
   const removeItem = item => {
-    setCart(prev =>
-      prev.filter(
-        i =>
-          !(
-            i.id === item.id &&
-            i.selectedSize === item.selectedSize &&
-            i.selectedColor === item.selectedColor
-          )
-      )
-    );
+    if (!item) return;
+    const variantId = item.variantId ?? item.variant_id;
+    setCart(prev => prev.filter(line => line.variantId !== variantId));
   };
 
   const decreaseItem = item => {
+    if (!item) return;
+    const variantId = item.variantId ?? item.variant_id;
     setCart(prev =>
       prev
-        .map(i =>
-          i.id === item.id &&
-          i.selectedSize === item.selectedSize &&
-          i.selectedColor === item.selectedColor
-            ? { ...i, quantity: i.quantity - 1 }
-            : i
-        )
-        .filter(i => i.quantity > 0)
+        .map(line => {
+          if (line.variantId !== variantId) return line;
+          const nextQuantity = line.quantity - 1;
+          return nextQuantity > 0 ? { ...line, quantity: nextQuantity } : null;
+        })
+        .filter(Boolean)
     );
   };
 
@@ -74,5 +128,4 @@ export function CartProvider({ children }) {
   return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
 }
 
-// ✅ export standard
 export { CartContext };

--- a/client/src/pages/Cart.jsx
+++ b/client/src/pages/Cart.jsx
@@ -11,7 +11,7 @@ const Cart = () => {
 
   const calculateTotal = () => {
     return cart.reduce((total, item) => {
-      return total + item.price * item.quantity;
+      return total + (Number(item.unit_price) || 0) * item.quantity;
     }, 0);
   };
 
@@ -31,28 +31,38 @@ const Cart = () => {
       <h1>Mon Panier</h1>
 
       <div className="cart-items">
-        {cart.map(item => (
-          <div
-            key={`${item.id}-${item.selectedSize}-${item.selectedColor}`}
-            className="cart-item"
-          >
-            <img src={item.item_images?.[0]?.image_url} alt={item.name} />
+        {cart.map(item => {
+          const unitPrice = Number(item.unit_price) || 0;
+          const stock = item.stock ?? null;
+          const cannotIncrease = stock != null && item.quantity >= stock;
+          return (
+            <div
+              key={`${item.variantId}`}
+              className="cart-item"
+            >
+              <img src={item.image_url} alt={item.name} />
             <div className="item-details">
               <h3>{item.name}</h3>
-              <p>{item.price}€</p>
-              <p>Taille: {item.selectedSize} | Couleur: {item.selectedColor}</p>
+              <p>{unitPrice.toFixed(2)}€</p>
+              <p>
+                Taille: {item.size || '—'} | Couleur: {item.color || '—'}
+              </p>
+              {stock != null && <p className="item-stock">Stock: {stock}</p>}
             </div>
             <div className="quantity-controls">
               <button onClick={() => decreaseItem(item)}>-</button>
               <span>{item.quantity}</span>
-              <button onClick={() => addItem(item)}>+</button>
+              <button onClick={() => addItem(item)} disabled={cannotIncrease}>
+                +
+              </button>
             </div>
-            <div className="item-total">{(item.price * item.quantity).toFixed(2)}€</div>
+            <div className="item-total">{(unitPrice * item.quantity).toFixed(2)}€</div>
             <button onClick={() => removeItem(item)} className="remove-btn">
               Supprimer
             </button>
-          </div>
-        ))}
+            </div>
+          );
+        })}
       </div>
 
       <div className="cart-summary">

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -54,7 +54,7 @@ export default function Home() {
         // Derniers articles
         const { data: latest, error: latestErr } = await supabase
           .from('items')
-          .select('*, item_images ( image_url )')
+          .select('*, item_images ( image_url ), item_variants ( id, size, color, price, stock )')
           .order('created_at', { ascending: false })
           .limit(8);
         if (latestErr) console.error(latestErr);
@@ -69,7 +69,7 @@ export default function Home() {
           const ids = topAgg.map(r => r.item_id);
           const { data: items, error: itemsErr } = await supabase
             .from('items')
-            .select('*, item_images ( image_url )')
+            .select('*, item_images ( image_url ), item_variants ( id, size, color, price, stock )')
             .in('id', ids);
           if (!itemsErr && items) {
             const map = new Map(items.map(i => [i.id, i]));

--- a/client/src/pages/ProductList.jsx
+++ b/client/src/pages/ProductList.jsx
@@ -28,6 +28,13 @@ export default function ProductList() {
           item_images (
             image_url
           ),
+          item_variants (
+            id,
+            size,
+            color,
+            price,
+            stock
+          ),
           categories (
             id,
             name


### PR DESCRIPTION
1.Préparation / cadrage
Décider du contrat : le prix de vente = item_variants.price. items.price = prix “à partir de” (min des variants) pour l’affichage.

Désactiver temporairement l’édition publique si tu as du trafic (bannière “maintenance admin”) le temps de migrer.

Base de données (migration)
Renommer format → size dans item_variants (si pas déjà fait).

Rendre item_variants.price NOT NULL (après backfill).

Contrainte d’unicité : unique(item_id, coalesce(size,''), coalesce(color,'')).

(Optionnel mais recommandé) order_items.variant_id SET NOT NULL + trigger de cohérence (variant.item_id == order_items.item_id).

Acceptation

Insérer deux variants de même (item,size,color) échoue.

Impossible d’insérer un variant sans prix.

(Si activé) impossible d’ajouter un order_item avec un variant d’un autre item.

Données existantes (backfill)
Script qui crée des variants à partir de items.sizes (et colors si utile), prix initial = items.price.

Mettre items.price = MIN(variants.price) par item.

(Optionnel) vider/ignorer items.sizes/colors côté métier (les garder pour affichage si tu veux).

Acceptation

Chaque item vivant a au moins 1 variant en base.

items.price reflète le min des variants.

RLS / Permissions (contrôle)
Vérifier que item_variants est lecture publique (anon, authenticated) et écriture admin (déjà OK dans ton schéma).

Aucune modif RLS requise pour order_items (tu sauvegardes unit_price côté serveur/secure).

Acceptation

Un client peut lire variants/prix.

Seul un admin peut créer/éditer variants.

Backend (si tu en as un) / Supabase RPC
Exposer une RPC create_item_with_sizes(name, …, p_sizes jsonb, p_colors text[]) (déjà fournie) ou gérer en front via 2 inserts transactionnels.

Endpoint Add to Cart: prend variant_id, vérifie le stock, fige unit_price (copie du prix du variant).

Acceptation

Appel d’ajout au panier refuse un variant_id invalide ou sans stock.

order_items.unit_price = item_variants.price au moment de l’ajout.

Admin Panel – Formulaire Produits
Remplacer l’éditeur de tailles par un éditeur de variants (table { size, price, stock, color? }).

À la soumission :

insert/update items (prix provisoire 0),

delete+insert (ou UPSERT) des item_variants,

update items.price = MIN(variants.price)

upload images inchangé.

Validation : au moins 1 variant, chaque variant a une taille et un prix valide.

Acceptation

Sauvegarder un produit sans variant échoue (UX claire).

Éditer un produit remplace proprement ses variants.

items.price se met à jour automatiquement.

Front – Liste / Cartes produits
Afficher le prix par défaut = min des variants : soit items.price (déjà min), soit calcul min côté client si besoin.

(Optionnel) Si tu veux “première taille en base” :

Récupérer item_variants triés par size ou created_at,

Afficher le prix du premier variant au lieu du min. (Je recommande min pour la cohérence UX “à partir de”.)

Acceptation

Chaque carte affiche un prix cohérent avec la page détail (min ou premier variant, selon ton choix).

Changer l’ordre des variants côté admin impacte l’affichage “première taille” si tu as choisi cette stratégie.

Front – Page Détail Produit
Charger les variants de l’item (select id, size, color, price, stock).

Sélecteur de taille (et couleur si utilisée) → filtre dynamique des combos valides.

Afficher le prix du variant sélectionné (pas items.price).

Désactiver “Ajouter au panier” si stock == 0.

État local : { selectedVariantId, selectedSize, selectedColor }.

Acceptation

Changer de taille met à jour instantanément le prix affiché.

Les tailles/couleurs non disponibles ne sont pas sélectionnables.

Bouton “Ajouter” indisponible si pas de variant sélectionné.

Panier / Add-to-cart
Payload d’ajout : { item_id, variant_id, quantity } (+ sécurité côté serveur/RPC).

Stock check à l’ajout (et idéalement au checkout).

Ligne panier affiche size, color, unit_price, total = unit_price * qty.

Si tu autorises la modification de taille dans le panier : c’est un changement de variant → mets à jour variant_id et unit_price.

Acceptation

Une ligne de panier reflète exactement le variant (taille/couleur) choisi et fige le prix.

Total panier = somme des unit_price * qty.

Checkout / Commande
À la création d’order_items, copier unit_price depuis item_variants.price (source de vérité).

orders.total = somme des order_items.total_price (tu l’as en colonne générée total_price sur la ligne).

(Optionnel) verrou stock : décrémenter le stock du variant au paiement confirmé (webhook).

Acceptation

La commande sauvegarde les prix figés même si tu changes les variants plus tard.

Total commande exact.

Tests fonctionnels (checklist)
Admin : créer item avec 1 taille unique → prix carte = prix unique.

Admin : créer item avec 3 tailles (prix différents) → carte affiche min (ou première taille selon choix).

Détail : changer taille → prix affiché change.

Panier : ajoute 2 tailles différentes du même item → deux lignes distinctes avec bons prix.

Édition : modifier prix d’une taille → nouvelle addition au panier prend le nouveau prix, l’ancienne ligne garde l’ancien (car figée).

RLS : un user non admin ne peut pas écrire variants.

Stock 0 : impossible d’ajouter au panier, bouton désactivé.

Technique / Qualité
Index item_variants(item_id, size, color) pour requêtes rapides.

SKU auto (slug + taille + couleur) si utile en logistique.

Gestion des erreurs UX : messages clairs (variant dupliqué, prix manquant).

Monitoring basic : log des insert variants et add-to-cart (gares aux erreurs RLS).

Nice-to-have (après livraison)
Tri des tailles (ordre personnalisé : U, XS, S, M, L, XL, XXL…).

Badges : “À partir de X€” sur carte / “Rupture” si tous variants à 0 stock.

Filtres catalogue par tailles/couleurs disponibles (via item_variants).